### PR TITLE
fix for the ununiform margins while exporting

### DIFF
--- a/swf/export.py
+++ b/swf/export.py
@@ -516,10 +516,12 @@ class SVGExporter(BaseExporter):
         # Setup svg @width, @height and @viewBox
         # and add the optional margin
         self.bounds = SVGBounds(self.svg)
-        self.svg.set("width", "%dpx" % round(self.bounds.width))
-        self.svg.set("height", "%dpx" % round(self.bounds.height))
-        if self._margin > 0:
-            self.bounds.grow(self._margin)
+
+        self.svg.set("width", "%dpx" % round(self.bounds.width + 2 * self._margin))
+        self.svg.set("height", "%dpx" % round(self.bounds.height + 2 * self._margin))
+
+        self.bounds.grow(self._margin)
+
         vb = [self.bounds.minx, self.bounds.miny, 
               self.bounds.width, self.bounds.height]
         self.svg.set("viewBox", "%s" % " ".join(map(str,vb)))


### PR DESCRIPTION
Things to consider:
- this fix changes the svg dimensions so probably breaks backward compatilibity
- this is the easiest fix for the problem

If you think about it if you have a rectangle that's not a square, if you extend it with the same margin in each direction the resulting rectangle will not be the same aspect ratio, so actually you cannot really solve this problem without changing svg size.
