### PR TITLE
pyswf is not checking the precense of a negative sceneCount value.

### DIFF
--- a/swf/tag.py
+++ b/swf/tag.py
@@ -1656,6 +1656,11 @@ class TagDefineSceneAndFrameLabelData(Tag):
 
     def parse(self, data, length, version=1):
         self.sceneCount = data.readEncodedU32()
+
+        if self.sceneCount >= 0x80000000:
+            print "WARNING: Negative sceneCount value: %x found!. SWF file exploiting CVE-2007-0071?" % self.sceneCount
+            return 
+
         self.scenes = []
         self.frameLabels = []
         for i in range(0, self.sceneCount):


### PR DESCRIPTION
I was getting the following exception when parsing a SWF file:

Traceback (most recent call last):
  File "../../../../swf_detection/tools/decompress_swf.py", line 59, in <module>
    swf_file = SWF(StringIO(raw_data))
  File "/usr/local/lib/python2.7/dist-packages/pyswf-1.3-py2.7.egg/swf/movie.py", line 87, in **init**
    self.parse(self._data)
  File "/usr/local/lib/python2.7/dist-packages/pyswf-1.3-py2.7.egg/swf/movie.py", line 143, in parse
    self.parse_tags(data)
  File "/usr/local/lib/python2.7/dist-packages/pyswf-1.3-py2.7.egg/swf/tag.py", line 112, in parse_tags
    tag = self.parse_tag(data)
  File "/usr/local/lib/python2.7/dist-packages/pyswf-1.3-py2.7.egg/swf/tag.py", line 130, in parse_tag
    tag.parse(data, raw_tag.header.content_length, tag.version)
  File "/usr/local/lib/python2.7/dist-packages/pyswf-1.3-py2.7.egg/swf/tag.py", line 1665, in parse
    for i in range(0, self.sceneCount):
MemoryError

The SWF file was specially crafted with a negative sceneCount value. 

Additional information: http://blog.threatexpert.com/2008/05/flash-exploit-goes-wild.html
