### PR TITLE
Provide a human readable compileTime representation

### DIFF
--- a/swf/tag.py
+++ b/swf/tag.py
@@ -2,6 +2,7 @@ from consts import *
 from data import *
 from utils import *
 from stream import *
+import datetime
 try:
     import Image
 except ImportError:
@@ -2144,7 +2145,7 @@ class TagProductInfo(Tag):
         s += " product: %s" % ProductKind.tostring(self.product)
         s += " edition: %s" % ProductEdition.tostring(self.edition)
         s += " major.minor.build: %d.%d.%d" % (self.majorVersion, self.minorVersion, self.build)
-        s += " compileTime: %d" % (self.compileTime)
+        s += " compileTime: %d (%s)" % (self.compileTime, datetime.datetime.fromtimestamp(self.compileTime//1000.0).ctime())
         return s
 
 class TagScriptLimits(Tag):


### PR DESCRIPTION
Original output: 
compileTime: 1235651171951

Output after the change:
compileTime: 1235651171951 (Thu Feb 26 07:26:11 2009)