### PR TITLE
Only re-read frame info when decompression occurs

### DIFF
--- a/swf/movie.py
+++ b/swf/movie.py
@@ -157,9 +157,9 @@ class SWF(SWFTimelineContainer):
                 temp.write(pylzma.decompress(data))
             temp.seek(0)
             data = SWFStream(temp)
-        self._header._frame_size = data.readRECT()
-        self._header._frame_rate = data.readFIXED8()
-        self._header._frame_count = data.readUI16()
+            self._header._frame_size = data.readRECT()
+            self._header._frame_rate = data.readFIXED8()
+            self._header._frame_count = data.readUI16()
         self.parse_tags(data)
         
     def __str__(self):


### PR DESCRIPTION
SWF.parse should only read frame information for compressed SWFs as the SWFHeader would have already read it for uncompressed SWFs.