### PR TITLE
Pillow 3.x removes fromstring() in favor of frombytes()

### DIFF
--- a/swf/export.py
+++ b/swf/export.py
@@ -14,6 +14,12 @@ try:
     import Image
 except ImportError:
     from PIL import Image
+
+    # Fix Pillow 1.x -> 3.x incompatibility:
+    # (fromstring was renamed to frombytes)
+    if not hasattr(Image, 'frombytes'):
+        Image.frombytes = Image.fromstring
+
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -425,7 +431,7 @@ class BaseExporter(object):
                         alpha = ord(tag.bitmapAlphaData.read(1))
                         rgb = list(image_data[i])
                         buff += struct.pack("BBBB", rgb[0], rgb[1], rgb[2], alpha)
-                    image = Image.fromstring("RGBA", (image_width, image_height), buff)
+                    image = Image.frombytes("RGBA", (image_width, image_height), buff)
         elif isinstance(tag, TagDefineBitsJPEG2):
             tag.bitmapData.seek(0)
             image = Image.open(tag.bitmapData)

--- a/swf/tag.py
+++ b/swf/tag.py
@@ -7,6 +7,12 @@ try:
     import Image
 except ImportError:
     from PIL import Image
+
+    # Fix Pillow 1.x -> 3.x incompatibility:
+    # (fromstring was renamed to frombytes)
+    if not hasattr(Image, 'frombytes'):
+        Image.frombytes = Image.fromstring
+
 import struct
 
 try:
@@ -888,7 +894,7 @@ class TagDefineBitsLossless(DefinitionTag):
             self.image_buffer = s.getvalue()
             s.close()
 
-            im = Image.fromstring("RGBA", (self.padded_width, self.bitmap_height), self.image_buffer)
+            im = Image.frombytes("RGBA", (self.padded_width, self.bitmap_height), self.image_buffer)
             im = im.crop((0, 0, self.bitmap_width, self.bitmap_height))
 
         elif self.bitmap_format == BitmapFormat.BIT_15:
@@ -907,7 +913,7 @@ class TagDefineBitsLossless(DefinitionTag):
                 b = ord(temp.read(1))
                 s.write(struct.pack("BBBB", r, g, b, a))
             self.image_buffer = s.getvalue()
-            im = Image.fromstring("RGBA", (self.bitmap_width, self.bitmap_height), self.image_buffer)
+            im = Image.frombytes("RGBA", (self.bitmap_width, self.bitmap_height), self.image_buffer)
         else:
             raise Exception("unhandled bitmap format! %s %d" % (BitmapFormat.tostring(self.bitmap_format), self.bitmap_format))
 


### PR DESCRIPTION
With Pillow 3.x, pyswf fails with certain .swf files with this error:

    Exception: fromstring() has been removed. Please call frombytes() instead.

This patch aims to fix that problem, while not breaking compatibility with PIL/Pillow 1.x.

For more information on this compatibility issue, see eg. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808279