### PR TITLE
Allow DefineFont without DefineFontInfo

### DIFF
--- a/swf/export.py
+++ b/swf/export.py
@@ -527,6 +527,17 @@ class SVGExporter(BaseExporter):
         self.fonts = dict([(x.characterId,x) for x in swf.all_tags_of_type(TagDefineFont)])
         self.fontInfos = dict([(x.characterId,x) for x in swf.all_tags_of_type(TagDefineFontInfo)])
 
+        # Make sure that all fonts have a fontInfos entry
+        for font_id in self.fonts.keys():
+            if font_id not in self.fontInfos:
+                info = TagDefineFontInfo()
+
+                # For now, draw characters as paths (instead of using SVG <text> elements)
+                info.useGlyphText = True
+
+                info.codeTable = self.fonts[font_id].codeTable
+                self.fontInfos[font_id] = info
+
         # GO!
         super(SVGExporter, self).export(swf, force_stroke)
 


### PR DESCRIPTION
Some .swf files seem to have `DefineFont` tags without corresponding `DefineFontInfo` a tag. This results in an error:

```
$ python bin/swf2svg.py --swf test.swf --svg test.svg
Traceback (most recent call last):
  File "bin/swf2svg.py", line 21, in <module>
    svg = swf.export(svg_exporter)
  File "/usr/local/lib/python2.7/site-packages/swf/movie.py", line 132, in export
    return exporter.export(self, force_stroke)
  File "/usr/local/lib/python2.7/site-packages/swf/export.py", line 531, in export
    super(SVGExporter, self).export(swf, force_stroke)
  File "/usr/local/lib/python2.7/site-packages/swf/export.py", line 404, in export
    self.export_define_shapes(swf.tags)
  File "/usr/local/lib/python2.7/site-packages/swf/export.py", line 474, in export_define_shapes
    self.export_define_font(tag)
  File "/usr/local/lib/python2.7/site-packages/swf/export.py", line 559, in export_define_font
    fontInfo = self.fontInfos[tag.characterId]
KeyError: 3
```

This PR aims to add a `fontInfos` entry even if the `DefineFontInfo` is missing. TBH, I haven't done much research on why the format is different in some files, but this patch should be quite safe anyway, since the new code is only run in case of missing tags.