### PR TITLE
Allow exporting sprites with SingleShapeSVGExporter

### DIFF
--- a/swf/tag.py
+++ b/swf/tag.py
@@ -152,7 +152,7 @@ class SWFTimelineContainer(DefinitionTag):
     def get_dependencies(self):
         """ Returns the character ids this tag refers to """
         s = super(SWFTimelineContainer, self).get_dependencies()
-        for dt in self.all_tags_of_type(DefinitionTag):
+        for dt in self.all_tags_of_type((DefinitionTag, TagPlaceObject)):
             s.update(dt.get_dependencies())
         return s
 


### PR DESCRIPTION
I'm trying to use `SingleShapeSVGExporter` to export a `TagDefineSprite`. Without this PR, the `get_dependencies()` method only gives the id of the sprite itself, thus not adding proper `defs` entries.

To me it would seem logical that all the `TagPlaceObject`s inside a `TagDefineSprite` would be seen as something that the sprite depends on. Can you see whether this PR could cause a problem elsewhere?

Or: should I not try to use `SingleShapeSVGExporter` to export a sprite?