### PR TITLE
Add --shape, --frame and --names options; use mixins instead of SVGExporter subclasses

### DIFF
--- a/bin/swf2svg.py
+++ b/bin/swf2svg.py
@@ -1,6 +1,6 @@
 import argparse
 from swf.movie import SWF
-from swf.export import SVGExporter, SingleShapeSVGExporterMixin, FrameSVGExporterMixin
+from swf.export import SVGExporter, SingleShapeSVGExporterMixin, FrameSVGExporterMixin, NamesSVGExporterMixin
 
 parser = argparse.ArgumentParser(description="Convert an SWF file into an SVG")
 parser.add_argument("--swf", type=argparse.FileType('rb'),
@@ -11,6 +11,8 @@ parser.add_argument("--shape", type=int,
                     help="Only export shape SHAPE (integer)", required=False)
 parser.add_argument("--frame", type=int,
                     help="Export frame FRAME (0-based index) instead of frame 0", required=False)
+parser.add_argument("--names", action='store_true',
+                    help='For each element, extract SWF instanceName to class="n-<name>"', required=False)
 
 options = parser.parse_args()
 argparse.swf_file = options.swf
@@ -31,6 +33,10 @@ if options.shape is not None:
 if options.frame is not None:
     export_mixins.append(FrameSVGExporterMixin)
     export_opts['frame'] = options.frame
+
+if options.names:
+    export_mixins.append(NamesSVGExporterMixin)
+
 
 # create the SVG exporter
 svg_exporter = SVGExporter()

--- a/bin/swf2svg.py
+++ b/bin/swf2svg.py
@@ -1,12 +1,16 @@
 import argparse
 from swf.movie import SWF
-from swf.export import SVGExporter
+from swf.export import SVGExporter, SingleShapeSVGExporterMixin, FrameSVGExporterMixin
 
 parser = argparse.ArgumentParser(description="Convert an SWF file into an SVG")
 parser.add_argument("--swf", type=argparse.FileType('rb'),
                     help="Location of SWG file to convert", required=True)
 parser.add_argument("--svg", type=argparse.FileType('wb'),
                     help="Location of converted SVG file", required=True)
+parser.add_argument("--shape", type=int,
+                    help="Only export shape SHAPE (integer)", required=False)
+parser.add_argument("--frame", type=int,
+                    help="Export frame FRAME (0-based index) instead of frame 0", required=False)
 
 options = parser.parse_args()
 argparse.swf_file = options.swf
@@ -14,11 +18,28 @@ argparse.swf_file = options.swf
 # load and parse the SWF
 swf = SWF(options.swf)
 
+export_opts = {}
+export_mixins = []
+
+
+# process the optional arguments
+
+if options.shape is not None:
+    export_mixins.append(SingleShapeSVGExporterMixin)
+    export_opts['shape'] = options.shape
+
+if options.frame is not None:
+    export_mixins.append(FrameSVGExporterMixin)
+    export_opts['frame'] = options.frame
+
 # create the SVG exporter
 svg_exporter = SVGExporter()
 
+# NB: Construct the class dynamically, since the chosen options dictate which mixins to use.
+svg_exporter.__class__ = type('ThisExporter', tuple(export_mixins + [SVGExporter]), {})
+
 # export!
-svg = swf.export(svg_exporter)
+svg = svg_exporter.export(swf, **export_opts)
 
 # save the SVG
 options.svg.write(svg.read())

--- a/swf/export.py
+++ b/swf/export.py
@@ -899,11 +899,24 @@ class FrameSVGExporterMixin(object):
 
                     if not tag.hasCharacter:
                         tag.characterId = orig_tag.characterId
+                    # this is for NamesSVGExporterMixin
+                    if not tag.hasName:
+                        tag.instanceName = orig_tag.instanceName
                 frame_tags[tag.depth] = tag
             elif isinstance(tag, TagRemoveObject):
                 del frame_tags[tag.depth]
 
         return super(FrameSVGExporterMixin, self).get_display_tags(frame_tags.values(), z_sorted)
+
+class NamesSVGExporterMixin(object):
+    '''
+    Add class="n-<name>" to SVG elements for tags that have an instanceName.
+    '''
+    def export_display_list_item(self, tag, parent=None):
+        use = super(NamesSVGExporterMixin, self).export_display_list_item(tag, parent)
+        if hasattr(tag, 'instanceName') and tag.instanceName is not None:
+            use.set('class', 'n-%s' % tag.instanceName)
+        return use
 
 
 class SVGFilterFactory(object):

--- a/swf/export.py
+++ b/swf/export.py
@@ -810,11 +810,36 @@ class SVGExporter(BaseExporter):
 class SingleShapeSVGExporter(SVGExporter):
     """
     An SVG exporter which knows how to export a single shape.
+    NB: This class is here just for backward compatibility.
+    Use SingleShapeSVGExporterMixin instead to mix with other functionality.
     """
     def __init__(self, margin=0):
         super(SingleShapeSVGExporter, self).__init__(margin = margin)
 
     def export_single_shape(self, shape_tag, swf):
+        class MySingleShapeSVGExporter(SingleShapeSVGExporterMixin, SVGExporter):
+            pass
+        exporter = MySingleShapeSVGExporter()
+        return exporter.export(swf, shape=shape_tag)
+
+class SingleShapeSVGExporterMixin(object):
+    def export(self, swf, shape, **export_opts):
+        """ Exports the specified shape of the SWF to SVG.
+
+        @param swf   The SWF.
+        @param shape Which shape to export, either by characterId(int) or as a Tag object.
+        """
+
+        # If `shape` is given as int, find corresponding shape tag.
+        if isinstance(shape, Tag):
+            shape_tag = shape
+        else:
+            shapes = [x for x in swf.all_tags_of_type((TagDefineShape, TagDefineSprite)) if x.characterId == shape]
+            if len(shapes):
+                shape_tag = shapes[0]
+            else:
+                raise Exception("Shape %s not found" % shape)
+
         from swf.movie import SWF
 
         # find a typical use of this shape
@@ -847,7 +872,39 @@ class SingleShapeSVGExporter(SVGExporter):
         stunt_swf = SWF()
         stunt_swf.tags = tags_to_export
 
-        return super(SingleShapeSVGExporter, self).export(stunt_swf)
+        return super(SingleShapeSVGExporterMixin, self).export(stunt_swf, **export_opts)
+
+class FrameSVGExporterMixin(object):
+    def export(self, swf, frame, **export_opts):
+        """ Exports a frame of the specified SWF to SVG.
+
+        @param swf   The SWF.
+        @param frame Which frame to export, by 0-based index (int)
+        """
+        self.wanted_frame = frame
+        return super(FrameSVGExporterMixin, self).export(swf, *export_opts)
+
+    def get_display_tags(self, tags, z_sorted=True):
+
+        current_frame = 0
+        frame_tags = dict() # keys are depths, values are placeobject tags
+        for tag in tags:
+            if isinstance(tag, TagShowFrame):
+                if current_frame == self.wanted_frame:
+                    break
+                current_frame += 1
+            elif isinstance(tag, TagPlaceObject):
+                if tag.hasMove:
+                    orig_tag = frame_tags.pop(tag.depth)
+
+                    if not tag.hasCharacter:
+                        tag.characterId = orig_tag.characterId
+                frame_tags[tag.depth] = tag
+            elif isinstance(tag, TagRemoveObject):
+                del frame_tags[tag.depth]
+
+        return super(FrameSVGExporterMixin, self).get_display_tags(frame_tags.values(), z_sorted)
+
 
 class SVGFilterFactory(object):
     # http://commons.oreilly.com/wiki/index.php/SVG_Essentials/Filters


### PR DESCRIPTION
NB: This PR contains the previous PR (#38).

In addition to #38, this adds a new mixin for exporting object names as classes.

---

This PR adds the possibility to extract a single SVG frame, i.e. other than the first frame.

I needed to do this for a single `DefineSprite` tag. Thus, I needed to combine two quite independent features: `SingleShapeSVGExporter` and the new chosen frame exporter. I chose to refactor the feature subclasses to mixins. Now `SVGExporter` can be augmented with the desired mixins, which need not know about one another. Each mixin parses its own specific `export()` keyword arguments.

Normally one would just write something like:

```
class MyFancySVGExporter(SingleShapeSVGExporterMixin, FrameSVGExporterMixin, SVGExporter):
    pass

svg = MyFancySVGExporter().export(...)
```

But `swg2svg.py` doesn't know the list of mixins needed until at runtime, that's why the `__class__` thing is needed there.
