### PR TITLE
Add python3 support

### DIFF
--- a/bin/swf2svg.py
+++ b/bin/swf2svg.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import argparse
 from swf.movie import SWF
 from swf.export import SVGExporter

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 from setuptools import setup, find_packages
 
@@ -19,7 +20,7 @@ setup(
     author_email='tim@floorplanner.com',
     url='https://github.com/timknip/pyswf',
 
-    install_requires = ["lxml>=3.3.0", "Pillow>=2.3.0", "pylzma>=0.4.6"],
+    install_requires = ["lxml>=3.3.0", "Pillow>=2.3.0", "pylzma>=0.4.6", "six"],
     packages=find_packages(),
     license = "MIT",
     classifiers=[

--- a/swf/actions.py
+++ b/swf/actions.py
@@ -1,4 +1,6 @@
 
+from __future__ import absolute_import
+import six
 class Action(object):
     def __init__(self, code, length):
         self._code = code
@@ -177,7 +179,7 @@ class ActionAnd(Action4):
 # urgh! some 100 to go...
 
 ActionTable = {}
-for name, value in dict(locals()).iteritems():
+for name, value in six.iteritems(dict(locals())):
     if type(value) == type and issubclass(value, Action) and hasattr(value, 'CODE'):
         ActionTable[value.CODE] = value
 

--- a/swf/data.py
+++ b/swf/data.py
@@ -1,5 +1,8 @@
-from consts import *
-from utils import *
+from __future__ import absolute_import
+from .consts import *
+from .utils import *
+from six.moves import map
+from six.moves import range
 
 class _dumb_repr(object):
     def __repr__(self):
@@ -70,7 +73,7 @@ class SWFShape(_dumb_repr):
     def export(self, handler=None):
         self._create_edge_maps()
         if handler is None:
-            from export import SVGShapeExporter
+            from .export import SVGShapeExporter
             handler = SVGShapeExporter()
         handler.begin_shape()
         for i in range(0, self.num_groups):
@@ -1340,7 +1343,7 @@ class SWFSoundInfo(_dumb_repr):
         self.outPoint = data.readUI32() if self.hasOutPoint else None
         self.loopCount = data.readUI16() if self.hasLoops else None
         self.envPointCount = data.readUI8() if self.hasEnvelope else None
-        self.envelopePoints = [data.readSOUNDENVELOPE() for x in xrange(self.envPointCount)] if self.hasEnvelope else None
+        self.envelopePoints = [data.readSOUNDENVELOPE() for x in range(self.envPointCount)] if self.hasEnvelope else None
 
     def __str__(self):
         return "[SWFSoundInfo]"

--- a/swf/export.py
+++ b/swf/export.py
@@ -1,23 +1,23 @@
 """
 This module defines exporters for the SWF fileformat.
 """
-from consts import *
-from geom import *
-from utils import *
-from data import *
-from tag import *
-from filters import *
+from __future__ import absolute_import
+from .consts import *
+from .geom import *
+from .utils import *
+from .data import *
+from .tag import *
+from .filters import *
 from lxml import objectify
 from lxml import etree
 import base64
+from six.moves import map
+from six.moves import range
 try:
     import Image
 except ImportError:
     from PIL import Image
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+from six.moves import cStringIO
 import math
 import re
 import copy
@@ -992,7 +992,7 @@ class SVGBounds(object):
     def _build_matrix(self, transform):
         if transform.find("matrix") >= 0:
             raw = str(transform).replace("matrix(", "").replace(")", "")
-            f = map(float, re.split("\s+|,", raw))
+            f = list(map(float, re.split("\s+|,", raw)))
             return Matrix2(f[0], f[1], f[2], f[3], f[4], f[5])
 
     def _calc_combined_matrix(self):

--- a/swf/export.py
+++ b/swf/export.py
@@ -17,6 +17,7 @@ try:
     import Image
 except ImportError:
     from PIL import Image
+from io import BytesIO
 from six.moves import cStringIO
 import math
 import re
@@ -405,7 +406,7 @@ class BaseExporter(object):
         self.export_display_list(self.get_display_tags(swf.tags))
 
     def export_define_bits(self, tag):
-        png_buffer = StringIO()
+        png_buffer = BytesIO()
         image = None
         if isinstance(tag, TagDefineBitsJPEG3):
 
@@ -425,14 +426,14 @@ class BaseExporter(object):
                         alpha = ord(tag.bitmapAlphaData.read(1))
                         rgb = list(image_data[i])
                         buff += struct.pack("BBBB", rgb[0], rgb[1], rgb[2], alpha)
-                    image = Image.fromstring("RGBA", (image_width, image_height), buff)
+                    image = Image.frombytes("RGBA", (image_width, image_height), buff)
         elif isinstance(tag, TagDefineBitsJPEG2):
             tag.bitmapData.seek(0)
             image = Image.open(tag.bitmapData)
         else:
             tag.bitmapData.seek(0)
             if self.jpegTables is not None:
-                buff = StringIO()
+                buff = BytesIO()
                 self.jpegTables.seek(0)
                 buff.write(self.jpegTables.read())
                 buff.write(tag.bitmapData.read())
@@ -545,7 +546,7 @@ class SVGExporter(BaseExporter):
         return self._serialize()
 
     def _serialize(self):
-        return StringIO(etree.tostring(self.svg,
+        return cStringIO(etree.tostring(self.svg,
                 encoding="UTF-8", xml_declaration=True))
 
     def export_define_sprite(self, tag, parent=None):
@@ -794,7 +795,7 @@ class SVGExporter(BaseExporter):
 
     def export_image(self, tag, image=None):
         if image is not None:
-            buff = StringIO()
+            buff = BytesIO()
             image.save(buff, "PNG")
             buff.seek(0)
             data_url = _encode_png(buff.read())

--- a/swf/filters.py
+++ b/swf/filters.py
@@ -1,4 +1,7 @@
-from utils import ColorUtils
+from __future__ import absolute_import
+from .utils import ColorUtils
+from six.moves import map
+from six.moves import range
 
 class Filter(object):
     """

--- a/swf/geom.py
+++ b/swf/geom.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import math
 
 SNAP = 0.001

--- a/swf/movie.py
+++ b/swf/movie.py
@@ -1,13 +1,11 @@
 """
 SWF
 """
-from tag import SWFTimelineContainer
-from stream import SWFStream
-from export import SVGExporter
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
+from __future__ import absolute_import
+from .tag import SWFTimelineContainer
+from .stream import SWFStream
+from .export import SVGExporter
+from six.moves import cStringIO
 
 class SWFHeaderException(Exception):
     """ Exception raised in case of an invalid SWFHeader """

--- a/swf/movie.py
+++ b/swf/movie.py
@@ -6,6 +6,7 @@ from .tag import SWFTimelineContainer
 from .stream import SWFStream
 from .export import SVGExporter
 from six.moves import cStringIO
+from io import BytesIO
 
 class SWFHeaderException(Exception):
     """ Exception raised in case of an invalid SWFHeader """
@@ -142,7 +143,7 @@ class SWF(SWFTimelineContainer):
         self._data = data = data if isinstance(data, SWFStream) else SWFStream(data)
         self._header = SWFHeader(self._data)
         if self._header.compressed:
-            temp = StringIO.StringIO()
+            temp = BytesIO()
             if self._header.compressed_zlib:
                 import zlib
                 data = data.f.read()

--- a/swf/sound.py
+++ b/swf/sound.py
@@ -1,7 +1,8 @@
-import consts
-import tag
+from __future__ import absolute_import
+from . import consts
+from . import tag
 import wave
-import stream
+from . import stream
 
 supportedCodecs = (
     consts.AudioCodec.MP3,

--- a/swf/stream.py
+++ b/swf/stream.py
@@ -51,7 +51,7 @@ class SWFStream(object):
     
     def _read_bytes_aligned(self, bytes):
         buf = self.f.read(bytes)
-        return reduce(lambda x, y: x << 8 | ord(y), buf, 0)
+        return reduce(lambda x, y: x << 8 | y, buf, 0)
     
     def readbits(self, bits):
         """
@@ -64,7 +64,7 @@ class SWFStream(object):
         
         # fast byte-aligned path
         if bits % 8 == 0 and self._bits_pending == 0:
-            return self._read_bytes_aligned(bits / 8)
+            return self._read_bytes_aligned(bits // 8)
         
         out = 0
         masks = self._masks
@@ -97,7 +97,7 @@ class SWFStream(object):
                 continue
             
             r = self.f.read(1)
-            if r == '':
+            if r == b'':
                 raise EOFError
             self._partial_byte = ord(r)
             self._bits_pending = 8
@@ -368,11 +368,11 @@ class SWFStream(object):
     def readString(self):
         """ Read a string """
         s = self.f.read(1)
-        string = ""
+        string = b""
         while ord(s) > 0:
             string += s
             s = self.f.read(1)
-        return string
+        return string.decode()
     
     def readFILTER(self):
         """ Read a SWFFilter """

--- a/swf/stream.py
+++ b/swf/stream.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import
 import struct, math
-from data import *
-from actions import *
-from filters import SWFFilterFactory
+from .data import *
+from .actions import *
+from .filters import SWFFilterFactory
+from six.moves import range
+from functools import reduce
 
 class SWFStream(object):
     """
@@ -381,7 +384,7 @@ class SWFStream(object):
     def readFILTERLIST(self):
         """ Read a length-prefixed list of FILTERs """
         number = self.readUI8()
-        return [self.readFILTER() for _ in xrange(number)]
+        return [self.readFILTER() for _ in range(number)]
     
     def readZONEDATA(self):
         """ Read a SWFZoneData """
@@ -440,14 +443,14 @@ class SWFStream(object):
         count = self.readUI8()
         if count == 0xff:
             count = self.readUI16()
-        return [self.readMORPHFILLSTYLE() for _ in xrange(count)]
+        return [self.readMORPHFILLSTYLE() for _ in range(count)]
         
     def readMORPHLINESTYLEARRAY(self, version):
         count = self.readUI8()
         if count == 0xff:
             count = self.readUI16()
         kind = self.readMORPHLINESTYLE if version == 1 else self.readMORPHLINESTYLE2
-        return [kind() for _ in xrange(count)]
+        return [kind() for _ in range(count)]
         
     def readraw_tag(self):
         """ Read a SWFRawTag """

--- a/swf/tag.py
+++ b/swf/tag.py
@@ -829,7 +829,7 @@ class TagDefineBitsLossless(DefinitionTag):
     """
     TYPE = 20
     bitmapData = None
-    image_buffer = ""
+    image_buffer = b""
     bitmap_format = 0
     bitmap_width = 0
     bitmap_height = 0
@@ -841,7 +841,7 @@ class TagDefineBitsLossless(DefinitionTag):
 
     def parse(self, data, length, version=1):
         import zlib
-        self.image_buffer = ""
+        self.image_buffer = b""
         self.characterId = data.readUI16()
         self.bitmap_format = data.readUI8()
         self.bitmap_width = data.readUI16()

--- a/swf/tag.py
+++ b/swf/tag.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     from PIL import Image
 import struct
+from io import BytesIO
 
-from six.moves import cStringIO
 
 class TagFactory(object):
     @classmethod
@@ -503,7 +503,7 @@ class TagDefineBits(DefinitionTag):
     TYPE = 6
     bitmapData = None
     def __init__(self):
-        self.bitmapData = StringIO.StringIO()
+        self.bitmapData = BytesIO()
         self.bitmapType = BitmapType.JPEG
         super(TagDefineBits, self).__init__()
 
@@ -516,7 +516,7 @@ class TagDefineBits(DefinitionTag):
         return TagDefineBits.TYPE
 
     def parse(self, data, length, version=1):
-        self.bitmapData = StringIO.StringIO()
+        self.bitmapData = BytesIO()
         self.characterId = data.readUI16()
         if length > 2:
             self.bitmapData.write(data.f.read(length - 2))
@@ -539,7 +539,7 @@ class TagJPEGTables(DefinitionTag):
 
     def __init__(self):
         super(TagJPEGTables, self).__init__()
-        self.jpegTables = StringIO.StringIO()
+        self.jpegTables = BytesIO()
 
     @property
     def name(self):
@@ -855,7 +855,7 @@ class TagDefineBitsLossless(DefinitionTag):
         # decompress zlib encoded bytes
         compressed_length = len(self.zlib_bitmap_data)
         zip = zlib.decompressobj()
-        temp = StringIO.StringIO()
+        temp = BytesIO()
         temp.write(zip.decompress(self.zlib_bitmap_data))
         temp.seek(0, 2)
         uncompressed_length = temp.tell()
@@ -869,7 +869,7 @@ class TagDefineBitsLossless(DefinitionTag):
 
         is_lossless2 = (type(self) == TagDefineBitsLossless2)
         im = None
-        self.bitmapData = StringIO.StringIO()
+        self.bitmapData = BytesIO()
 
         indexed_colors = []
         if self.bitmap_format == BitmapFormat.BIT_8:
@@ -881,13 +881,13 @@ class TagDefineBitsLossless(DefinitionTag):
                 indexed_colors.append(struct.pack("BBBB", r, g, b, a))
 
             # create the image buffer
-            s = StringIO.StringIO()
+            s = BytesIO()
             for i in range(t):
                 s.write(indexed_colors[ord(temp.read(1))])
             self.image_buffer = s.getvalue()
             s.close()
 
-            im = Image.fromstring("RGBA", (self.padded_width, self.bitmap_height), self.image_buffer)
+            im = Image.frombytes("RGBA", (self.padded_width, self.bitmap_height), self.image_buffer)
             im = im.crop((0, 0, self.bitmap_width, self.bitmap_height))
 
         elif self.bitmap_format == BitmapFormat.BIT_15:
@@ -896,7 +896,7 @@ class TagDefineBitsLossless(DefinitionTag):
             # we have no padding, since PIX24s are 32-bit aligned
             t = self.bitmap_width * self.bitmap_height
             # read PIX24's
-            s = StringIO.StringIO()
+            s = BytesIO()
             for i in range(0, t):
                 if not is_lossless2:
                     temp.read(1) # reserved, always 0
@@ -906,9 +906,9 @@ class TagDefineBitsLossless(DefinitionTag):
                 b = ord(temp.read(1))
                 s.write(struct.pack("BBBB", r, g, b, a))
             self.image_buffer = s.getvalue()
-            im = Image.fromstring("RGBA", (self.bitmap_width, self.bitmap_height), self.image_buffer)
+            im = Image.frombytes("RGBA", (self.bitmap_width, self.bitmap_height), self.image_buffer)
         else:
-            raise Exception("unhandled bitmap format! %s %d" % (BitmapFormat.tostring(self.bitmap_format), self.bitmap_format))
+            raise Exception("unhandled bitmap format! %s %d" % (BitmapFormat.tobytes(self.bitmap_format), self.bitmap_format))
 
         if not im is None:
             im.save(self.bitmapData, "PNG")
@@ -1214,7 +1214,7 @@ class TagDefineBitsJPEG3(TagDefineBitsJPEG2):
     """
     TYPE = 35
     def __init__(self):
-        self.bitmapAlphaData = StringIO.StringIO()
+        self.bitmapAlphaData = BytesIO()
         super(TagDefineBitsJPEG3, self).__init__()
 
     @property
@@ -1237,8 +1237,8 @@ class TagDefineBitsJPEG3(TagDefineBitsJPEG2):
         import zlib
         self.characterId = data.readUI16()
         alphaOffset = data.readUI32()
-        self.bitmapAlphaData = StringIO.StringIO()
-        self.bitmapData = StringIO.StringIO()
+        self.bitmapAlphaData = BytesIO()
+        self.bitmapData = BytesIO()
         self.bitmapData.write(data.f.read(alphaOffset))
         self.bitmapData.seek(0)
         self.bitmapType = ImageUtils.get_image_type(self.bitmapData)
@@ -1248,7 +1248,7 @@ class TagDefineBitsJPEG3(TagDefineBitsJPEG2):
             self.bitmapAlphaData.seek(0)
             # decompress zlib encoded bytes
             zip = zlib.decompressobj()
-            temp = StringIO.StringIO()
+            temp = BytesIO()
             temp.write(zip.decompress(self.bitmapAlphaData.read()))
             temp.seek(0)
             self.bitmapAlphaData = temp
@@ -1458,7 +1458,7 @@ class TagDefineFont2(TagDefineFont):
         self.languageCode = data.readLANGCODE()
 
         fontNameLen = data.readUI8()
-        fontNameRaw = StringIO.StringIO()
+        fontNameRaw = BytesIO()
         fontNameRaw.write(data.f.read(fontNameLen))
         fontNameRaw.seek(0)
         self.fontName = fontNameRaw.read()
@@ -1928,7 +1928,7 @@ class TagDefineSound(Tag):
         self.soundChannels = data.readUB(1)
         self.soundSamples = data.readUI32()
         # used 2 + 1 + 4 bytes here
-        self.soundData = StringIO.StringIO(data.read(length - 7))
+        self.soundData = BytesIO(data.read(length - 7))
 
     def __str__(self):
         s = super(TagDefineSound, self).__str__()
@@ -2077,7 +2077,7 @@ class TagSoundStreamBlock(Tag):
     def parse(self, data, length, version=1):
         # unfortunately we can't see our associated SoundStreamHead from here,
         # so just stash the data
-        self.data = StringIO.StringIO(data.read(length))
+        self.data = BytesIO(data.read(length))
 
     def complete_parse_with_header(self, head):
         stream = SWFStream(self.data)

--- a/swf/tag.py
+++ b/swf/tag.py
@@ -1,18 +1,17 @@
-from consts import *
-from data import *
-from utils import *
-from stream import *
+from __future__ import absolute_import
+from .consts import *
+from .data import *
+from .utils import *
+from .stream import *
 import datetime
+from six.moves import range
 try:
     import Image
 except ImportError:
     from PIL import Image
 import struct
 
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
+from six.moves import cStringIO
 
 class TagFactory(object):
     @classmethod
@@ -883,7 +882,7 @@ class TagDefineBitsLossless(DefinitionTag):
 
             # create the image buffer
             s = StringIO.StringIO()
-            for i in xrange(t):
+            for i in range(t):
                 s.write(indexed_colors[ord(temp.read(1))])
             self.image_buffer = s.getvalue()
             s.close()
@@ -2220,7 +2219,7 @@ class TagExportAssets(Tag):
 
     def parse(self, data, length, version=1):
         self.count = data.readUI16()
-        self.exports = [data.readEXPORT() for i in xrange(self.count)]
+        self.exports = [data.readEXPORT() for i in range(self.count)]
 
     def __str__(self):
         s = super(TagExportAssets, self).__str__()
@@ -2642,7 +2641,7 @@ class TagDefineMorphShape2(TagDefineMorphShape):
 
 if __name__ == '__main__':
     # some table checks
-    for x in xrange(256):
+    for x in range(256):
         y = TagFactory.create(x)
         if y:
             assert y.type == x, y.name + ' is misnamed'

--- a/swf/utils.py
+++ b/swf/utils.py
@@ -1,4 +1,5 @@
-from consts import BitmapType
+from __future__ import absolute_import
+from .consts import BitmapType
 import math
 
 class NumberUtils(object):

--- a/test/test_swf.py
+++ b/test/test_swf.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from swf.movie import SWF
 
 def test_header():


### PR DESCRIPTION
Fixes issue #34

Steps taken:

```
$ pip install modernize
$ for f in $(find . -path ./venv -prune -o -name '*.py' -print); do python-modernize -w $f; done
```

Then manual adjustments to setup.py (adding the `six` dependency), as well as some fixes for cStringIO to `swf/export.py`, `swf/movie.py` and `swf/tag.py`.

Has not been rigorously tested yet, but the included test script completes successfully.