### PR TITLE
Change StringIO to BytesIO to work on Python 3.

### DIFF
--- a/swf/export.py
+++ b/swf/export.py
@@ -13,6 +13,7 @@ from lxml import etree
 import base64
 from six.moves import map
 from six.moves import range
+from six import unichr
 try:
     import Image
 except ImportError:

--- a/swf/export.py
+++ b/swf/export.py
@@ -18,7 +18,6 @@ try:
 except ImportError:
     from PIL import Image
 from io import BytesIO
-from six.moves import cStringIO
 import math
 import re
 import copy
@@ -542,11 +541,11 @@ class SVGExporter(BaseExporter):
               self.bounds.width, self.bounds.height]
         self.svg.set("viewBox", "%s" % " ".join(map(str,vb)))
 
-        # Return the SVG as StringIO
+        # Return the SVG as BytesIO
         return self._serialize()
 
     def _serialize(self):
-        return cStringIO(etree.tostring(self.svg,
+        return BytesIO(etree.tostring(self.svg,
                 encoding="UTF-8", xml_declaration=True))
 
     def export_define_sprite(self, tag, parent=None):

--- a/swf/export.py
+++ b/swf/export.py
@@ -421,7 +421,7 @@ class BaseExporter(object):
                 image_data = image.getdata()
                 image_data_len = len(image_data)
                 if num_alpha == image_data_len:
-                    buff = ""
+                    buff = b""
                     for i in range(0, num_alpha):
                         alpha = ord(tag.bitmapAlphaData.read(1))
                         rgb = list(image_data[i])
@@ -1100,10 +1100,10 @@ class SVGBounds(object):
         self._matrix = self._calc_combined_matrix()
 
 def _encode_jpeg(data):
-    return "data:image/jpeg;base64," + base64.encodestring(data)[:-1]
+    return b"data:image/jpeg;base64," + base64.encodestring(data)[:-1]
 
 def _encode_png(data):
-    return "data:image/png;base64," + base64.encodestring(data)[:-1]
+    return b"data:image/png;base64," + base64.encodestring(data)[:-1]
 
 def _swf_matrix_to_matrix(swf_matrix=None, need_scale=False, need_translate=True, need_rotation=False, unit_div=20.0):
 

--- a/swf/movie.py
+++ b/swf/movie.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 from .tag import SWFTimelineContainer
 from .stream import SWFStream
 from .export import SVGExporter
-from six.moves import cStringIO
 from io import BytesIO
 
 class SWFHeaderException(Exception):

--- a/test/test_swf.py
+++ b/test/test_swf.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from swf.movie import SWF
+from swf.export import SVGExporter
 
 def test_header():
 
@@ -8,3 +9,12 @@ def test_header():
     swf = SWF(f)
 
     assert swf.header.frame_count == 1
+
+def test_export():
+    f = open('./test/data/test.swf', 'rb')
+    swf = SWF(f)
+
+    svg_exporter = SVGExporter()
+    svg = svg_exporter.export(swf)
+
+    assert b'<svg xmlns' in svg.read()


### PR DESCRIPTION
Exporting fails when using cStringIO. I noticed most were changed to BytesIO, but this one was missed.