### PR TITLE
docs: fix simple typo, maximim -> maximum

### DIFF
--- a/swf/stream.py
+++ b/swf/stream.py
@@ -24,7 +24,7 @@ class SWFStream(object):
         return str(s) if s<=1 else bin(s>>1) + str(s&1)
         
     def calc_max_bits(self, signed, values):
-        """ Calculates the maximim needed bits to represent a value """
+        """ Calculates the maximum needed bits to represent a value """
         b = 0
         vmax = -10000000
         


### PR DESCRIPTION
There is a small typo in swf/stream.py.

Should read `maximum` rather than `maximim`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md